### PR TITLE
Avoid double unlocking in TransitionManager

### DIFF
--- a/stately-core/src/main/java/io/stately/core/TransitionManager.java
+++ b/stately-core/src/main/java/io/stately/core/TransitionManager.java
@@ -55,7 +55,7 @@ public class TransitionManager<A, S, E, ID> {
     }
   }
 
-  public void transitionInternal(ID aggregateId, E event, TransitionHandler<A, S, E> handler) {
+  private void transitionInternal(ID aggregateId, E event, TransitionHandler<A, S, E> handler) {
     // Оборачиваем всю логику перехода в транзакцию
     fsmTransactionManager.executeInTransaction(() -> {
       A agg = store.loadForUpdate(aggregateId);
@@ -105,7 +105,5 @@ public class TransitionManager<A, S, E, ID> {
 
       return null; // Void operation
     });
-
-    locking.unlock(aggregateType, aggregateId);
   }
 }


### PR DESCRIPTION
## Summary
- prevent double unlocking by removing stray unlock call from `transitionInternal`
- restrict `transitionInternal` visibility to private to avoid misuse

## Testing
- `./gradlew build` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2, status code 403)*
- `./gradlew :stately-core:build`


------
https://chatgpt.com/codex/tasks/task_e_68aa0df9f3d483258add6f6a0390da64