### PR TITLE
feat: move idempotencyKey from metadata to transition

### DIFF
--- a/examples/order-demo/src/main/java/io/stately/examples/order/service/OrderFsmService.java
+++ b/examples/order-demo/src/main/java/io/stately/examples/order/service/OrderFsmService.java
@@ -30,7 +30,7 @@ public class OrderFsmService {
 
     // 2) FSM: сменим состояние, залогируем переход и положим команду во внешку в outbox (emit)
     tm.transition(
-        id, OrderEvent.SUBMIT, ctx -> {
+        id, OrderEvent.SUBMIT, idempotencyKey, ctx -> {
           // Демонстрируем использование action для бизнес-логики
           ctx.action(order -> {
             // Для immutable record это демонстрация концепции
@@ -39,8 +39,6 @@ public class OrderFsmService {
                                    ", current order amount: " + order.amount());
             return order.withAmount(orderAmount);
           });
-
-          ctx.metadata(Map.of("idempotencyKey", idempotencyKey));
           ctx.emit(
               OutboxEventType.CALL_PAYMENT_PROVIDER_AUTHORIZE,
               PaymentAuthorizationPayload.of(id, orderAmount, "USD"),

--- a/stately-core/src/main/java/io/stately/core/TransitionContext.java
+++ b/stately-core/src/main/java/io/stately/core/TransitionContext.java
@@ -22,7 +22,7 @@ public final class TransitionContext<A> {
    */
   private final List<Action<A>> actions = new ArrayList<>();
   /**
-   * Произвольная мета: например, idempotencyKey / operationId.
+   * Произвольная мета: например, operationId.
    */
   private Map<String, Object> meta = new HashMap<>();
 


### PR DESCRIPTION
## Summary
- Add idempotencyKey parameter to TransitionManager and capture it instead of metadata
- Remove idempotencyKey from metadata usage in OrderFsmService example
- Clean up TransitionContext comment

## Testing
- `./gradlew test` *(fails: java.lang.IllegalStateException at DockerClientProviderStrategy.java:277)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1f2dc0fc8325b94d094f1707eabc