### PR TITLE
feat: dispatch outbox events immediately with fallback scheduler

### DIFF
--- a/examples/order-demo/src/main/java/io/stately/examples/order/service/OutboxDispatcher.java
+++ b/examples/order-demo/src/main/java/io/stately/examples/order/service/OutboxDispatcher.java
@@ -1,0 +1,40 @@
+package io.stately.examples.order.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stately.core.store.OutboxEvent;
+import io.stately.core.store.OutboxProcessor;
+import io.stately.examples.order.fsm.persistence.OutboxRepository;
+import io.stately.examples.order.sync.OperationWaiter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxDispatcher implements OutboxProcessor {
+
+  private final OutboxRepository repo;
+  private final ObjectMapper om;
+  private final OperationWaiter waiter;
+
+  @Override
+  public void processOutboxEvents(List<OutboxEvent> events) {
+    for (var e : events) {
+      try {
+        JsonNode payload = om.valueToTree(e.payload());
+        // Integration with provider...
+        boolean ok = true;
+        String details = "external-ok";
+
+        repo.updateStatusById(e.id(), "DONE");
+        if (e.operationId() != null) {
+          waiter.complete(e.operationId(), new OperationWaiter.Result(ok, details));
+        }
+      } catch (Exception ex) {
+        // Leave status as NEW for scheduler retry
+        log.warn("Outbox dispatch failed for event {}", e.id(), ex);
+      }
+    }
+  }
+}

--- a/examples/order-demo/src/main/java/io/stately/examples/order/service/OutboxRecoveryJob.java
+++ b/examples/order-demo/src/main/java/io/stately/examples/order/service/OutboxRecoveryJob.java
@@ -1,44 +1,23 @@
 package io.stately.examples.order.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stately.core.store.OutboxEvent;
+import io.stately.core.store.OutboxProcessor;
 import io.stately.examples.order.fsm.persistence.OutboxEntity;
 import io.stately.examples.order.fsm.persistence.OutboxRepository;
-import io.stately.examples.order.sync.OperationWaiter;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 
 @RequiredArgsConstructor
 public class OutboxRecoveryJob {
 
   private final OutboxRepository repo;
-  private final NamedParameterJdbcTemplate jdbc;
-  private final ObjectMapper om;
-  private final OperationWaiter waiter;
+  private final OutboxProcessor dispatcher;
 
   @Scheduled(fixedDelay = 200)
   public void tick() {
     List<OutboxEntity> batch = repo.pickBatch(50);
-    for (var e : batch) {
-      try {
-        JsonNode payload = om.valueToTree(e.payload());
-        // Integration with provider...
-        boolean ok = true;
-        String details = "external-ok";
-
-        repo.updateStatusById(e.id(), "DONE");
-
-        if (e.operationId() != null) {
-          waiter.complete(e.operationId(), new OperationWaiter.Result(ok, details));
-        }
-      } catch (Exception ex) {
-        repo.updateStatusById(e.id(), "ERROR");
-        if (e.operationId() != null) {
-          waiter.complete(e.operationId(), new OperationWaiter.Result(false, ex.getMessage()));
-        }
-      }
-    }
+    dispatcher.processOutboxEvents(new ArrayList<OutboxEvent>(batch));
   }
 }


### PR DESCRIPTION
## Summary
- Add OutboxProcessor to TransitionManager and invoke it after transitions for immediate dispatch
- Wire Order demo with an OutboxDispatcher and scheduled recovery job that retries failed events
- Expose OutboxDispatcher bean and integrate into TransitionManager

## Testing
- `./gradlew test` *(fails: java.lang.IllegalStateException at DockerClientProviderStrategy.java:277)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1f2dc0fc8325b94d094f1707eabc